### PR TITLE
Support WIN_CHECKPOWERMODE1 outputs 0x80-0x83

### DIFF
--- a/src/atacmds.c
+++ b/src/atacmds.c
@@ -115,8 +115,10 @@ enum e_powermode ata_get_powermode(int device) {
          state = PWM_UNKNOWN;
        else
          state = PWM_SLEEPING;
+    } else if (args[2] == 0xFF || (args[2] & 0xFC) == 0x80) {
+       state = PWM_ACTIVE;
     } else {
-       state = ( (args[2] == 0xFF) ? PWM_ACTIVE : PWM_STANDBY );
+       state = PWM_STANDBY;
     }
 
   return state;


### PR DESCRIPTION
These are idle state variants, so treat them the same way as 0xFF.

See #13